### PR TITLE
chore: side bar removed

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,12 +12,6 @@
     </head>
     
     <body>
-        <side>
-            <img src="images/share.png" id="icon">
-            <a href="https://github.com/Shivam010"><img src="images/git.png" id="git"></a>
-            <a href="http://fb.com/shivam.rathore010"><img src="images/fb.png" id="fb"></a>
-            <a href="https://plus.google.com/+ShivamRathore010"><img src="images/google.png" id="g"></a>
-        </side>
         <center>
             <div id="block">
                 <p id="heading">Tic Tac Toe</p>


### PR DESCRIPTION
The side bar chip seems to be too clumsy for the whole page. Also, G+ is no longer available. So, its better to remove the whole side bar chip.